### PR TITLE
Finestructure patch 1

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,8 +2,8 @@ version: 1
 builder:
   configs:
   - platform: linux
-    swift_version: '5.8'
-    image: registry.gitlab.com/finestructure/spi-images:val-5.8-latest
+    swift_version: '5.9'
+    image: registry.gitlab.com/finestructure/spi-images:val-5.9-latest
     documentation_targets:
     - CLI
     - CodeGenLLVM
@@ -22,3 +22,9 @@ builder:
     --source-service-base-url, https://github.com/val-lang/val/blob/main,
     --checkout-path, .
     ]
+  - platform: linux
+    swift_version: '5.8'
+    image: registry.gitlab.com/finestructure/spi-images:val-5.8-latest
+  - platform: linux
+    swift_version: '5.7'
+    image: registry.gitlab.com/finestructure/spi-images:val-5.7-latest

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,10 @@
 version: 1
 builder:
   configs:
-  - documentation_targets:
+  - platform: linux
+    swift_version: '5.8'
+    image: registry.gitlab.com/finestructure/spi-images:val-5.8-latest
+    documentation_targets:
     - CLI
     - CodeGenLLVM
     - Core


### PR DESCRIPTION
This configures SPI to
- use a custom base image when building on Linux
- use Linux and Swift 5.9 to generate docs

See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2545 for details