### PR TITLE
Generate metatypes for tuple types

### DIFF
--- a/Sources/Core/Types/TupleType.swift
+++ b/Sources/Core/Types/TupleType.swift
@@ -28,12 +28,7 @@ public struct TupleType: TypeProtocol {
   /// Creates a tuple type with a sequence of elements.
   public init<S: Sequence>(_ elements: S) where S.Element == Element {
     self.elements = Array(elements)
-
-    var fs = TypeFlags(merging: self.elements.map(\.type.flags))
-    if (self.elements.count == 1) && (self.elements[0].label == nil) {
-      fs.remove(.isCanonical)
-    }
-    self.flags = fs
+    self.flags = TypeFlags(merging: self.elements.map(\.type.flags))
   }
 
   /// Creates a tuple type with a sequence of label-type pairs.

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -220,7 +220,7 @@ public struct TypedProgram {
   public func storage(of t: AnyType) -> [TupleType.Element] {
     switch t.base {
     case let u as BoundGenericType:
-      return storage(of: u.base)
+      return storage(of: u)
     case let u as LambdaType:
       return storage(of: u)
     case let u as ProductType:
@@ -230,6 +230,14 @@ public struct TypedProgram {
     default:
       assert(!t.hasRecordLayout)
       return []
+    }
+  }
+
+  /// Returns the names and types of `t`'s stored properties.
+  public func storage(of t: BoundGenericType) -> [TupleType.Element] {
+    storage(of: t.base).map { (p) in
+      let t = specialize(p.type, for: t.arguments, in: AnyScopeID(base.ast.coreLibrary!))
+      return .init(label: p.label, type: t)
     }
   }
 

--- a/Sources/IR/Operands/Instruction/SubfieldView.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldView.swift
@@ -62,7 +62,7 @@ extension Module {
     of recordAddress: Operand, subfield elementPath: RecordPath, at site: SourceRange
   ) -> SubfieldView {
     precondition(type(of: recordAddress).isAddress)
-    let l = AbstractTypeLayout(of: type(of: recordAddress).ast, definedIn: program)
+    let l = AbstractTypeLayout(of: self.type(of: recordAddress).ast, definedIn: program)
     return .init(
       base: recordAddress,
       subfield: elementPath,


### PR DESCRIPTION
This PR partially addresses #758. A complete fix requires associated type requirement checking, which has not been implemented yet.